### PR TITLE
Updated and Created /stats Endpoints

### DIFF
--- a/api/db/database.py
+++ b/api/db/database.py
@@ -91,61 +91,62 @@ def create_test_data():
         player_ids = session.execute(select(Player.id)).all()
     
     # Create Stats for the Players
-    for i in (range(100)):
-        year = random.randint(2012, 2022)
-        game_date = date.today() - timedelta(days=i)
-        rand_team = "Christopher Newport University"
-        rand_opponent = opponents[random.randint(0, 7)]
-        season = f"{year}-{year+1}"
-        fgm = random.randint(0, 20)
-        fga = random.randint(1, 20)
-        fg_pct = fgm/fga
-        three_fgm = random.randint(0, 10)
-        three_fga = random.randint(1, 10)
-        three_pt_pct = three_fgm/three_fga
-        ftm = random.randint(0, 10)
-        fta = random.randint(1, 10)
-        ft_pct = ftm/fta
-        off_reb = random.randint(0, 7)
-        def_reb = random.randint(0, 7)
-        tot_reb = random.randint(0, 7)
-        pf = random.randint(0, 5)
-        ast = random.randint(0, 7)
-        to = random.randint(0, 7)
-        blk = random.randint(0, 7)
-        stl = random.randint(0, 7)
-        pts = random.randint(0, 45)
-        player_num = random.randint(0,4)
-        player_id = player_ids[player_num][0]
-        
-        stat = StatLine(
-            date = game_date,
-            team = rand_team,
-            opponent = rand_opponent,
-            season = season,
-            fgm = fgm,
-            fga = fga,
-            fg_pct = fg_pct,
-            three_fgm = three_fgm,
-            three_fga = three_fga,
-            three_pt_pct = three_pt_pct,
-            ftm = ftm,
-            fta = fta,
-            ft_pct = ft_pct,
-            off_reb = off_reb,
-            def_reb = def_reb,
-            tot_reb = tot_reb,
-            pf = pf,
-            ast = ast,
-            to = to,
-            blk = blk,
-            stl = stl,
-            pts = pts,
-            player_id=player_id
-        )
-        
-        session.add(stat)
-    session.commit()
+    if not session.execute(select(StatLine.id)).all():
+        for i in (range(100)):
+            year = random.randint(2012, 2022)
+            game_date = date.today() - timedelta(days=i)
+            rand_team = "Christopher Newport University"
+            rand_opponent = opponents[random.randint(0, 7)]
+            season = f"{year}-{year+1}"
+            fgm = random.randint(0, 15)
+            fga = random.randint(15, 30)
+            fg_pct = fgm/fga
+            three_fgm = random.randint(0, 8)
+            three_fga = random.randint(8, 20)
+            three_pt_pct = three_fgm/three_fga
+            ftm = random.randint(0, 8)
+            fta = random.randint(8, 20)
+            ft_pct = ftm/fta
+            off_reb = random.randint(0, 7)
+            def_reb = random.randint(0, 7)
+            tot_reb = random.randint(0, 7)
+            pf = random.randint(0, 5)
+            ast = random.randint(0, 7)
+            to = random.randint(0, 7)
+            blk = random.randint(0, 7)
+            stl = random.randint(0, 7)
+            pts = random.randint(0, 45)
+            player_num = random.randint(0,4)
+            player_id = player_ids[player_num][0]
+            
+            stat = StatLine(
+                date = game_date,
+                team = rand_team,
+                opponent = rand_opponent,
+                season = season,
+                fgm = fgm,
+                fga = fga,
+                fg_pct = fg_pct,
+                three_fgm = three_fgm,
+                three_fga = three_fga,
+                three_pt_pct = three_pt_pct,
+                ftm = ftm,
+                fta = fta,
+                ft_pct = ft_pct,
+                off_reb = off_reb,
+                def_reb = def_reb,
+                tot_reb = tot_reb,
+                pf = pf,
+                ast = ast,
+                to = to,
+                blk = blk,
+                stl = stl,
+                pts = pts,
+                player_id=player_id
+            )
+            
+            session.add(stat)
+        session.commit()
     
     
 if __name__ == '__main__':

--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,7 @@
 from typing import Union
 from db.models import *
 from db.database import engine, create_db_and_tables, create_test_data
-from sqlmodel import Session, select
+from sqlmodel import Session, func, select
 from fastapi import FastAPI, HTTPException, Depends
 import os
 from os.path import join, dirname
@@ -44,7 +44,7 @@ def root():
 
 @app.get("/players/")
 def read_players(*, session: Session = Depends(get_session)):
-    players = session.exec(select(Player)).all()
+    players = session.exec(select(Player).order_by(Player.full_name)).all()
     return players
     
 @app.get("/players/{player_id}", response_model=PlayerRead)
@@ -80,21 +80,25 @@ def update_player(*, session: Session = Depends(get_session),player_id: UUID, pl
 #region Team
 @app.get("/teams/")
 def read_team(*, session: Session = Depends(get_session)):
-    teams = session.exec(select(StatLine.opponent).distinct()).all()
+    teams = session.exec(select(StatLine.opponent).distinct().order_by(StatLine.opponent)).all()
     return teams
 #endregion Team
 
 #region Games
 @app.get("/games/")
 def read_games(*, session: Session = Depends(get_session)):
-    games = session.exec(select(StatLine.date, StatLine.team, StatLine.opponent).distinct(StatLine.date)).all()
+    games = session.exec(
+        select(StatLine.date, StatLine.team, StatLine.opponent)
+        .distinct(StatLine.date)
+        .order_by(StatLine.date)
+        ).all()
     return games
 #endregion Games
 
 #region Seasons
 @app.get("/seasons/")
 def read_seasons(*, session: Session = Depends(get_session)):
-    seasons = session.exec(select(StatLine.season).distinct()).all()
+    seasons = session.exec(select(StatLine.season).distinct().order_by(StatLine.season)).all()
     return seasons
 
 #endregion Seasons
@@ -126,6 +130,306 @@ def update_statline(*, session: Session = Depends(get_session),statline_id: UUID
     session.commit()
     session.refresh(db_statline)
     return db_statline
+
+#region Stats Player
+@app.get("/stats/player")
+def get_all_stats_all_players(*, session: Session = Depends(get_session)):
+    """
+    Endpoint that returns the aggregated stats of each CNU player.
+    """
+    player_stats = session.exec(
+        select(
+            Player.full_name,
+            StatLine.player_id,
+            func.sum(StatLine.ftm).label('ftm'), 
+            func.sum(StatLine.fta).label('fta'),
+            func.avg(StatLine.ft_pct).label('ft_pct'),
+            func.sum(StatLine.fga).label('fga'),
+            func.sum(StatLine.fgm).label('fgm'),
+            func.avg(StatLine.fg_pct).label('fg_pct'),
+            func.sum(StatLine.three_fga).label('three_fga'),
+            func.sum(StatLine.three_fgm).label('three_fgm'),
+            func.avg(StatLine.three_pt_pct).label('three_pt_pct'),
+            func.sum(StatLine.off_reb).label('off_reb'),
+            func.sum(StatLine.def_reb).label('def_reb'),
+            func.sum(StatLine.tot_reb).label('tot_reb'),
+            func.sum(StatLine.pf).label('pf'),
+            func.sum(StatLine.ast).label('ast'),
+            func.sum(StatLine.to).label('to'),
+            func.sum(StatLine.blk).label('blk'),
+            func.sum(StatLine.stl).label('stl'),
+            func.sum(StatLine.pts).label('pts'),
+            )
+        .join(Player)
+        .group_by(Player.full_name)
+        ).all()
+    
+    return player_stats
+
+@app.get("/stats/players/{player_id}")
+def get_all_stats_by_player(*, session: Session = Depends(get_session),player_id: UUID):
+    """Endpoint that returns the stats of an individual CNU player as found by the players ID.
+
+    Args:
+        player_id (UUID): UUID unique to the player that is being looked for
+    """
+    player_stats = session.exec(
+        select(
+            Player.full_name,
+            StatLine.player_id,
+            func.sum(StatLine.ftm).label('ftm'), 
+            func.sum(StatLine.fta).label('fta'),
+            func.avg(StatLine.ft_pct).label('ft_pct'),
+            func.sum(StatLine.fga).label('fga'),
+            func.sum(StatLine.fgm).label('fgm'),
+            func.avg(StatLine.fg_pct).label('fg_pct'),
+            func.sum(StatLine.three_fga).label('three_fga'),
+            func.sum(StatLine.three_fgm).label('three_fgm'),
+            func.avg(StatLine.three_pt_pct).label('three_pt_pct'),
+            func.sum(StatLine.off_reb).label('off_reb'),
+            func.sum(StatLine.def_reb).label('def_reb'),
+            func.sum(StatLine.tot_reb).label('tot_reb'),
+            func.sum(StatLine.pf).label('pf'),
+            func.sum(StatLine.ast).label('ast'),
+            func.sum(StatLine.to).label('to'),
+            func.sum(StatLine.blk).label('blk'),
+            func.sum(StatLine.stl).label('stl'),
+            func.sum(StatLine.pts).label('pts'),
+            )
+        .where(StatLine.player_id == player_id)
+        .join(Player)
+        .group_by(Player.full_name)
+        ).all()
+    
+    if not player_stats:
+        raise HTTPException(status_code=404, detail="Stats for Player requested not found")
+    
+    return player_stats
+#endregion Stats Player
+
+#region Stats Team
+@app.get("/stats/teams")
+def get_all_stats_all_teams(*, session: Session = Depends(get_session)):
+    """
+    Endpoint that returns the aggregated stats of CNU Players against each team.
+    """
+    # season_stats = (session.query(StatLine).group_by(StatLine.season).order_by(StatLine.season))
+    team_stats = session.exec(
+        select(
+            StatLine.opponent,
+            func.sum(StatLine.ftm).label('ftm'), 
+            func.sum(StatLine.fta).label('fta'),
+            func.avg(StatLine.ft_pct).label('ft_pct'),
+            func.sum(StatLine.fga).label('fga'),
+            func.sum(StatLine.fgm).label('fgm'),
+            func.avg(StatLine.fg_pct).label('fg_pct'),
+            func.sum(StatLine.three_fga).label('three_fga'),
+            func.sum(StatLine.three_fgm).label('three_fgm'),
+            func.avg(StatLine.three_pt_pct).label('three_pt_pct'),
+            func.sum(StatLine.off_reb).label('off_reb'),
+            func.sum(StatLine.def_reb).label('def_reb'),
+            func.sum(StatLine.tot_reb).label('tot_reb'),
+            func.sum(StatLine.pf).label('pf'),
+            func.sum(StatLine.ast).label('ast'),
+            func.sum(StatLine.to).label('to'),
+            func.sum(StatLine.blk).label('blk'),
+            func.sum(StatLine.stl).label('stl'),
+            func.sum(StatLine.pts).label('pts'),
+            )
+        .group_by(StatLine.opponent)
+        ).all()
+    
+    return team_stats
+
+@app.get("/stats/teams/{team_name}")
+def get_all_stats_by_team(*, session: Session = Depends(get_session),team_name: str):
+    """Endpoint that returns all of the stats of CNU against an individual opponent as found by the team name.
+
+    Args:
+        team_name (str): string representation of the team (the opponent) that is being looked for
+    """
+    team_stats = session.exec(
+        select(
+            StatLine.opponent,
+            func.sum(StatLine.ftm).label('ftm'), 
+            func.sum(StatLine.fta).label('fta'),
+            func.avg(StatLine.ft_pct).label('ft_pct'),
+            func.sum(StatLine.fga).label('fga'),
+            func.sum(StatLine.fgm).label('fgm'),
+            func.avg(StatLine.fg_pct).label('fg_pct'),
+            func.sum(StatLine.three_fga).label('three_fga'),
+            func.sum(StatLine.three_fgm).label('three_fgm'),
+            func.avg(StatLine.three_pt_pct).label('three_pt_pct'),
+            func.sum(StatLine.off_reb).label('off_reb'),
+            func.sum(StatLine.def_reb).label('def_reb'),
+            func.sum(StatLine.tot_reb).label('tot_reb'),
+            func.sum(StatLine.pf).label('pf'),
+            func.sum(StatLine.ast).label('ast'),
+            func.sum(StatLine.to).label('to'),
+            func.sum(StatLine.blk).label('blk'),
+            func.sum(StatLine.stl).label('stl'),
+            func.sum(StatLine.pts).label('pts'),
+            )
+        .where(StatLine.opponent == team_name)
+        .group_by(StatLine.opponent)
+        ).all()
+    
+    if not team_stats:
+        raise HTTPException(status_code=404, detail="Stats for Team requested not found")
+    
+    return team_stats
+#endregion Stats Team
+
+#region Stats Season
+@app.get("/stats/season")
+def get_all_stats_all_seasons(*, session: Session = Depends(get_session)):
+    """
+    Endpoint that returns the aggregated stats of CNU for each season.
+    """
+    # season_stats = (session.query(StatLine).group_by(StatLine.season).order_by(StatLine.season))
+    season_stats = session.exec(
+        select(
+            StatLine.season,
+            func.sum(StatLine.ftm).label('ftm'), 
+            func.sum(StatLine.fta).label('fta'),
+            func.avg(StatLine.ft_pct).label('ft_pct'),
+            func.sum(StatLine.fga).label('fga'),
+            func.sum(StatLine.fgm).label('fgm'),
+            func.avg(StatLine.fg_pct).label('fg_pct'),
+            func.sum(StatLine.three_fga).label('three_fga'),
+            func.sum(StatLine.three_fgm).label('three_fgm'),
+            func.avg(StatLine.three_pt_pct).label('three_pt_pct'),
+            func.sum(StatLine.off_reb).label('off_reb'),
+            func.sum(StatLine.def_reb).label('def_reb'),
+            func.sum(StatLine.tot_reb).label('tot_reb'),
+            func.sum(StatLine.pf).label('pf'),
+            func.sum(StatLine.ast).label('ast'),
+            func.sum(StatLine.to).label('to'),
+            func.sum(StatLine.blk).label('blk'),
+            func.sum(StatLine.stl).label('stl'),
+            func.sum(StatLine.pts).label('pts'),
+            )
+        .group_by(StatLine.season)
+        ).all()
+    
+    return season_stats
+
+@app.get("/stats/season/{season_year}")
+def get_all_stats_by_season(*, session: Session = Depends(get_session),season_year: str):
+    """Endpoint that returns the stats of CNU in an individual season as found by the season years.
+
+    Args:
+        season_years (str): years of the season (e.g. 2012-2013) that is being looked for.
+    """
+    season_stats = session.exec(
+        select(
+            StatLine.season,
+            func.sum(StatLine.ftm).label('ftm'), 
+            func.sum(StatLine.fta).label('fta'),
+            func.avg(StatLine.ft_pct).label('ft_pct'),
+            func.sum(StatLine.fga).label('fga'),
+            func.sum(StatLine.fgm).label('fgm'),
+            func.avg(StatLine.fg_pct).label('fg_pct'),
+            func.sum(StatLine.three_fga).label('three_fga'),
+            func.sum(StatLine.three_fgm).label('three_fgm'),
+            func.avg(StatLine.three_pt_pct).label('three_pt_pct'),
+            func.sum(StatLine.off_reb).label('off_reb'),
+            func.sum(StatLine.def_reb).label('def_reb'),
+            func.sum(StatLine.tot_reb).label('tot_reb'),
+            func.sum(StatLine.pf).label('pf'),
+            func.sum(StatLine.ast).label('ast'),
+            func.sum(StatLine.to).label('to'),
+            func.sum(StatLine.blk).label('blk'),
+            func.sum(StatLine.stl).label('stl'),
+            func.sum(StatLine.pts).label('pts'),
+            )
+        .where(StatLine.season == season_year)
+        .group_by(StatLine.season)
+        ).all()
+    
+    if not season_stats:
+        raise HTTPException(status_code=404, detail="Stats for Season requested not found")
+    
+    return season_stats
+#endregion Stats Season
+
+#region Stats Game
+@app.get("/stats/games")
+def get_all_stats_all_games(*, session: Session = Depends(get_session)):
+    """
+    Endpoint that returns the aggregated stats of CNU each game.
+    """
+
+    game_stats = session.exec(
+        select(
+            StatLine.date,
+            StatLine.team,
+            StatLine.opponent,
+            func.sum(StatLine.ftm).label('ftm'), 
+            func.sum(StatLine.fta).label('fta'),
+            func.avg(StatLine.ft_pct).label('ft_pct'),
+            func.sum(StatLine.fga).label('fga'),
+            func.sum(StatLine.fgm).label('fgm'),
+            func.avg(StatLine.fg_pct).label('fg_pct'),
+            func.sum(StatLine.three_fga).label('three_fga'),
+            func.sum(StatLine.three_fgm).label('three_fgm'),
+            func.avg(StatLine.three_pt_pct).label('three_pt_pct'),
+            func.sum(StatLine.off_reb).label('off_reb'),
+            func.sum(StatLine.def_reb).label('def_reb'),
+            func.sum(StatLine.tot_reb).label('tot_reb'),
+            func.sum(StatLine.pf).label('pf'),
+            func.sum(StatLine.ast).label('ast'),
+            func.sum(StatLine.to).label('to'),
+            func.sum(StatLine.blk).label('blk'),
+            func.sum(StatLine.stl).label('stl'),
+            func.sum(StatLine.pts).label('pts'),
+            )
+        .group_by(StatLine.date)
+        ).all()
+    
+    return game_stats
+
+@app.get("/stats/games/{game_date}")
+def get_all_stats_by_game(*, session: Session = Depends(get_session),game_date: datetime.date):
+    """Endpoint that returns the stats of CNU in an individual game as found by the game date.
+
+    Args:
+        game_date (str): date of the game that was played (e.g. 01-01-2012) that is being looked for.
+    """
+    game_stats = session.exec(
+        select(
+            StatLine.date,
+            StatLine.team,
+            StatLine.opponent,
+            func.sum(StatLine.ftm).label('ftm'), 
+            func.sum(StatLine.fta).label('fta'),
+            func.avg(StatLine.ft_pct).label('ft_pct'),
+            func.sum(StatLine.fga).label('fga'),
+            func.sum(StatLine.fgm).label('fgm'),
+            func.avg(StatLine.fg_pct).label('fg_pct'),
+            func.sum(StatLine.three_fga).label('three_fga'),
+            func.sum(StatLine.three_fgm).label('three_fgm'),
+            func.avg(StatLine.three_pt_pct).label('three_pt_pct'),
+            func.sum(StatLine.off_reb).label('off_reb'),
+            func.sum(StatLine.def_reb).label('def_reb'),
+            func.sum(StatLine.tot_reb).label('tot_reb'),
+            func.sum(StatLine.pf).label('pf'),
+            func.sum(StatLine.ast).label('ast'),
+            func.sum(StatLine.to).label('to'),
+            func.sum(StatLine.blk).label('blk'),
+            func.sum(StatLine.stl).label('stl'),
+            func.sum(StatLine.pts).label('pts'),
+            )
+        .where(StatLine.date == game_date)
+        .group_by(StatLine.date)
+        ).all()
+    
+    if not game_stats:
+        raise HTTPException(status_code=404, detail="Stats for Game requested not found")
+    
+    return game_stats
+#endregion Stats Game
+
 #endregion Stats
 
 #region Game Stats
@@ -155,30 +459,3 @@ def create_gamestat(*, gamestat: GameStatCreate, session: Session = Depends(get_
     session.refresh(db_gamestat)
     return db_gamestat
 #endregion Game Stats
-
-#region Entity Stat Endpoints
-""" 
-Want to follow the syntax of /stats/{entity}/{entity.id}
-That way we can get the data of an individual player, team, game, season but for the entity
-For example /stats/players/2 will return all the statlines for the player with the matching ID
-Can let the front end handle the aggregation and math. That should hopefully reduce the need for any 
-preprocessing or query strings in the URL.
-"""
-
-# @app.get("/stats/players/{player_id}", response_model=PlayerWithStatLines)
-# def get_players_stats(*, session: Session = Depends(get_session), player_id: UUID):
-#     pass
-
-# @app.get("/stats/teams/{team_id}", response_model=TeamWithStatLines)
-# def get_teams_stats(*, session: Session = Depends(get_session), team_id: UUID):
-#     pass
-
-# @app.get("/stats/seasons/{season_id}", response_model=SeasonWithStatLines)
-# def get_seasons_stats(*, session: Session = Depends(get_session), season_id: UUID):
-#     pass
-
-# @app.get("/stats/games/{game_id}", response_model=GameWithStatLines)
-# def get_games_stats(*, session: Session = Depends(get_session), game_id: UUID):
-#     pass
-
-#endregion Entity Stat Endpoints


### PR DESCRIPTION
Updated `/stats` endpoints that return CNU Player data and aggregates accordingly.

Updates to code should address the following requirements:
- `/stats`
    - `/players`: will return all CNU players data aggregated and grouped by individual players
    - `/players/{player_id}`: will return all CNU player data for a single player identified by player's ID aggregated by individual player.
    - `/season`: will return all CNU players data aggregated and grouped by each season
    - `/season/{season_year}`: will return all CNU players data aggregated and grouped by single season identified by a string representation of the year in format "[startYear]-[endYear]" (e.g. "2022-2023") 
    - `/team`: will return all CNU players data aggregated and grouped by each opposing team
    - `/team/{team_name}`: will return all CNU players data aggregated and grouped by single opposing team identified by a string representation of the team's name (e.g. "Salisbury University")
    -  `/games`: will return all CNU players data aggregated and grouped by each game
    - `/games/{games_date}`: will return all CNU players data aggregated and grouped by single game identified by a string representation of the game date in format "YYYY-MM-DD" (e.g. "2023-03-30")
- Additional Changes were made to the player model to facilitate the changes above
- Docstrings were added to some functions to add to auto created documentation for endpoints.
- Changes were made to the dummy data generating function to avoid creating deuplicate/too much data when testing locally